### PR TITLE
Correct missing include

### DIFF
--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -9,6 +9,7 @@
 #include "sound.h"
 
 #include <cassert>
+#include <kos/dbglog.h>
 
 int Sound::m_default_vol = 240;
 


### PR DESCRIPTION
Update to explicitly include dbglog ahead of removing it from stdio in KOS.

EDIT: Dropped keyboard deprecation switch as it should be done with version tests to prevent breaking with versions prior to v2.2.0 (like was done for SDL).